### PR TITLE
Use dict instead or OrderedDict for Python 3.6+

### DIFF
--- a/knowit/__init__.py
+++ b/knowit/__init__.py
@@ -23,5 +23,9 @@ try:
     from collections import OrderedDict
 except ImportError:  # pragma: no cover
     from ordereddict import OrderedDict
+else:
+    import sys
+    if sys.version_info >= (3, 6):
+        OrderedDict = dict
 
 from .api import KnowitException, know


### PR DESCRIPTION
OrderedDict is unnecessary in Python 3.6+ as dict is ordered by default.