### PR TITLE
Py3/test latest

### DIFF
--- a/knowit/utils.py
+++ b/knowit/utils.py
@@ -85,7 +85,11 @@ def define_candidate(locations, names, os_family=None, suggested_path=None):
 
         if location == '__PATH__':
             for name in names[os_family]:
-                yield name
+                if os_family == 'windows':
+                    for path in os.environ['PATH'].split(';'):
+                        yield os.path.join(path, name)
+                else:
+                    yield name
         elif os.path.isfile(location):
             yield location
         elif os.path.isdir(location):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py33,py34,py35,py36}-{native}
+envlist = {py27,py33,py34,py35,py36,py37,py38,py39}-{native}
 
 [testenv]
 commands =


### PR DESCRIPTION
This adds tests on 3.7, 3.8, and 3.9 and fixes a bug with loading `MediaInfo.dll` on Windows with Python 3.8+.

See https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew